### PR TITLE
Add provider validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,7 +44,10 @@ def validate_env_vars(provider):
         ],
         'S3_DO': ['S3_ENDPOINT_URL', 'S3_ACCESS_KEY', 'S3_SECRET_KEY']
     }
-    
+
+    if provider not in required_vars:
+        raise ValueError(f"Unsupported provider: {provider}")
+
     missing_vars = [var for var in required_vars[provider] if not os.getenv(var)]
     if missing_vars:
         vars_list = ', '.join(missing_vars)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,12 @@ def test_validate_env_vars_missing(monkeypatch):
     with pytest.raises(ValueError):
         cfg.validate_env_vars('GCP')
 
+
+def test_validate_env_vars_unknown_provider(monkeypatch):
+    cfg = reload_config(monkeypatch, API_KEY='x')
+    with pytest.raises(ValueError, match="Unsupported provider: UNKNOWN"):
+        cfg.validate_env_vars('UNKNOWN')
+
 @pytest.mark.parametrize(
     "provider, env_vars, should_raise",
     [


### PR DESCRIPTION
## Summary
- validate provider names in config
- test for unsupported providers

## Testing
- `ruff check . --select E,F` *(fails: SyntaxError in tests/test_generate_docs.py)*
- `pytest -q` *(fails: ModuleNotFoundError for flask and syntax error in tests/test_generate_docs.py)*

------
https://chatgpt.com/codex/tasks/task_e_6868297758a08327a47580a68263a170